### PR TITLE
Made var section open

### DIFF
--- a/Source/Core/BaseRow.swift
+++ b/Source/Core/BaseRow.swift
@@ -98,7 +98,7 @@ open class BaseRow: BaseRowType {
     public var isHidden: Bool { return hiddenCache }
 
     /// The section to which this row belongs.
-    public weak var section: Section?
+    open weak var section: Section?
 
     public required init(tag: String? = nil) {
         self.tag = tag


### PR DESCRIPTION
In order to allow it to be overwritten by a row which subclasses it. This is needed for the new custom row `SplitRow`. `SplitRow` enables to put two Eureka rows side by side into one UITableViewCell.

